### PR TITLE
Herald start time and other fixes

### DIFF
--- a/herald.py
+++ b/herald.py
@@ -66,11 +66,15 @@ async def playHerald(member):
     # Only run if user has selected audio
     if member.id in heraldDict.keys():
 
+        print(f'{member.name} has played Herald!')
+
         # Connect to voice channel
+        time.sleep(0.5)
         vc = await member.voice.channel.connect()
 
         # Set and start audio
         audio = FFmpegPCMAudio(heraldDict[member.id].mp3Link)
+        time.sleep(0.5)
         vc.play(audio)
 
         # Wait for duration

--- a/herald.py
+++ b/herald.py
@@ -3,8 +3,10 @@ from pytube import YouTube
 import pickle
 from discord import FFmpegPCMAudio
 
+default_duration = 15
+
 class HeraldUser:
-    def __init__(self, mp3Link_in, lastUseTime_in = 0, startTime_in = 0, duration_in = 15):
+    def __init__(self, mp3Link_in, lastUseTime_in = 0, startTime_in = 0, duration_in = default_duration):
         self.mp3Link = mp3Link_in
         self.lastUseTime = lastUseTime_in
         self.startTime = startTime_in
@@ -34,6 +36,12 @@ async def runHerald(ctx, args):
             # New user
             heraldDict[ctx.author.id] = HeraldUser(f'herald/{ctx.author.id}_audio.mp3')
             await ctx.send("User initialized with new Herald")
+
+        # Ensure the playback does not last longer than possible
+        if video.length < default_duration:
+            heraldDict[ctx.author.id].duration = video.length
+        else:
+            heraldDict[ctx.author.id].duration = default_duration
 
     elif len(args) == 2 and args[0] == 'duration':
         # If there are two arguments and the first is 'duration' then the user is

--- a/herald.py
+++ b/herald.py
@@ -27,6 +27,11 @@ async def runHerald(ctx, args):
         except:
             await ctx.send("Not a valid YouTube link")
             return
+
+        # Video cannot be longer than 10 minutes
+        if video.length > 600:
+            await ctx.send("Video is too long (greater than 10 minutes)")
+            return
         
         stream = video.streams.filter(only_audio = True).first()
         stream.download("herald", filename = f'{ctx.author.id}.mp3')
@@ -71,9 +76,11 @@ async def runHerald(ctx, args):
 
             else:
                 await ctx.send("Duration must be less than or equal to 30 seconds")
+                return
         else:
             # User does NOT exist so they need to first pick their audio
             await ctx.send("You do not have a chosen audio, run /herald link")
+            return
 
     elif len(args) == 2 and args[0] == 'start':
         # If there are two arguments and the first is 'start' then the user is
@@ -99,14 +106,18 @@ async def runHerald(ctx, args):
                 if (heraldDict[ctx.author.id].audioLength - start_time) < heraldDict[ctx.author.id].duration:
                     heraldDict[ctx.author.id].duration = heraldDict[ctx.author.id].audioLength - start_time
 
+                await ctx.send("Start time updated")
+
             else:
                 # The start time is greater than the length of the audio
                 await ctx.send("The start time requested is beyond the end of the audio")
+                return
 
         
         else:
             # User does NOT exist so they need to first pick their audio
             await ctx.send("You do not have a chosen audio, run /herald link")
+            return
 
     else:
         await ctx.send("A link is needed, run /herald link")

--- a/herald.py
+++ b/herald.py
@@ -2,7 +2,6 @@ from helper import *
 from pytube import YouTube
 from pydub import AudioSegment
 import pickle
-from discord import FFmpegPCMAudio
 
 default_duration = 15
 millisecond_conversion = 1000
@@ -48,6 +47,7 @@ async def runHerald(ctx, args):
             heraldDict[ctx.author.id].duration = default_duration
 
         heraldDict[ctx.author.id].audioLength = video.length
+        heraldDict[ctx.author.id].startTime = 0
         heraldDict[ctx.author.id].editedMp3Link = heraldDict[ctx.author.id].mp3Link
 
     elif len(args) == 2 and args[0] == 'duration':
@@ -60,7 +60,7 @@ async def runHerald(ctx, args):
 
             # Duration cannot be greater than 30
             if duration <= 30:
-                
+
                 # Duration cannot extend past the end of the audio so we adjust here
                 if duration > heraldDict[ctx.author.id].audioLength - heraldDict[ctx.author.id].startTime:
                     heraldDict[ctx.author.id].duration = heraldDict[ctx.author.id].audioLength - heraldDict[ctx.author.id].startTime
@@ -91,9 +91,6 @@ async def runHerald(ctx, args):
 
                 # Create a new audio that starts at the desired time
                 edited_audio = audio[start_time*millisecond_conversion:]
-
-                # Reduce volume by 3 dB
-                edited_audio = edited_audio - 3
 
                 edited_audio.export(f'herald/{ctx.author.id}_edited.mp3', format='mp3')
                 heraldDict[ctx.author.id].editedMp3Link = f'herald/{ctx.author.id}_edited.mp3'
@@ -129,9 +126,9 @@ async def playHerald(member):
         vc = await member.voice.channel.connect()
 
         # Set and start audio
-        audio = FFmpegPCMAudio(heraldDict[member.id].editedMp3Link)
+        audio = discord.FFmpegPCMAudio(heraldDict[member.id].editedMp3Link)
         time.sleep(0.5)
-        vc.play(audio)
+        vc.play(discord.PCMVolumeTransformer(audio, volume=0.7))
 
         # Wait for duration
         time.sleep(heraldDict[member.id].duration)

--- a/herald.py
+++ b/herald.py
@@ -25,7 +25,7 @@ async def runHerald(ctx, args):
         try:
             video = YouTube(args[0])
         except:
-            await ctx.send("Not a valid YouTube link")
+            await ctx.send("Not a valid YouTube link, run /herald link")
             return
 
         # Video cannot be longer than 10 minutes
@@ -118,6 +118,11 @@ async def runHerald(ctx, args):
             # User does NOT exist so they need to first pick their audio
             await ctx.send("You do not have a chosen audio, run /herald link")
             return
+
+    elif len(args) == 2:
+        # user used a flag that does not exist
+        await ctx.send(f"Herald does not have a flag for '{args[0]}', run /herald link")
+        return
 
     else:
         await ctx.send("A link is needed, run /herald link")


### PR DESCRIPTION
Closes #18:
* Added start time functionality
* Adjusted volume to 70%
* Set default duration to video length if it's shorter than the video length (and added other duration changes regarding the start time implementation)
* Added a join delay to help ensure the new user has time to hear their own audio
* Added max video length so my hard drive doesn't die